### PR TITLE
Add support for `mongodb@5`

### DIFF
--- a/lib/agenda/database.ts
+++ b/lib/agenda/database.ts
@@ -34,30 +34,28 @@ export const database = function (
 
   collection = collection || "agendaJobs";
 
-  MongoClient.connect(url, options, (error, client) => {
-    if (error) {
+  MongoClient.connect(url, options).then(
+    (client) => {
+      debug(
+        "successful connection to MongoDB using collection: [%s]",
+        collection
+      );
+      if (client) {
+        this._db = client;
+        this._mdb = client.db();
+        this.db_init(collection, cb);
+      } else {
+        throw new Error("Mongo Client is undefined");
+      }
+    },
+    (error) => {
       debug("error connecting to MongoDB using collection: [%s]", collection);
       if (cb) {
         cb(error, null);
       } else {
         throw error;
       }
-
-      return;
-    }
-
-    debug(
-      "successful connection to MongoDB using collection: [%s]",
-      collection
-    );
-
-    if (client) {
-      this._db = client;
-      this._mdb = client.db();
-      this.db_init(collection, cb);
-    } else {
-      throw new Error("Mongo Client is undefined");
-    }
-  });
+    },
+  );
   return this;
 };

--- a/lib/agenda/db-init.ts
+++ b/lib/agenda/db-init.ts
@@ -25,21 +25,24 @@ export const dbInit = function (
   }
 
   debug("attempting index creation");
+  const handler = (error?: AnyError) => {
+    if (error) {
+      debug("index creation failed");
+      this.emit("error", error);
+    } else {
+      debug("index creation success");
+      this.emit("ready");
+    }
+
+    if (cb) {
+      cb(error, this._collection);
+    }
+  };
   this._collection.createIndex(
     this._indices,
     { name: "findAndLockNextJobIndex" },
-    (error) => {
-      if (error) {
-        debug("index creation failed");
-        this.emit("error", error);
-      } else {
-        debug("index creation success");
-        this.emit("ready");
-      }
-
-      if (cb) {
-        cb(error, this._collection);
-      }
-    }
+  ).then(
+    () => handler(),
+    (error) => handler(error)
   );
 };

--- a/lib/agenda/stop.ts
+++ b/lib/agenda/stop.ts
@@ -17,29 +17,23 @@ export const stop = async function (this: Agenda): Promise<void> {
    * @returns resolves when job unlocking fails or passes
    */
   const _unlockJobs = async (): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      debug("Agenda._unlockJobs()");
-      const jobIds = this._lockedJobs.map((job) => job.attrs._id);
+    debug("Agenda._unlockJobs()");
+    const jobIds = this._lockedJobs.map((job) => job.attrs._id);
 
-      if (jobIds.length === 0) {
-        debug("no jobs to unlock");
-        resolve();
-      }
+    if (jobIds.length === 0) {
+      debug("no jobs to unlock");
+      return;
+    }
 
-      debug("about to unlock jobs with ids: %O", jobIds);
-      this._collection.updateMany(
+    debug("about to unlock jobs with ids: %O", jobIds);
+    try {
+      await this._collection.updateMany(
         { _id: { $in: jobIds } },
-        { $set: { lockedAt: null } },
-        (error) => {
-          if (error) {
-            reject(error);
-          }
-
-          this._lockedJobs = [];
-          resolve();
-        }
+        { $set: { lockedAt: null } }
       );
-    });
+    } finally {
+      this._lockedJobs = [];
+    }
   };
 
   debug("Agenda.stop called, clearing interval for processJobs()");


### PR DESCRIPTION
Since `mongodb@5` no longer supports callbacks, we've changed the code that still uses callbacks to use promises instead. This PR effectively adds support for `mongodb@5`.